### PR TITLE
fix: Update API URLs to use v2 endpoints

### DIFF
--- a/Interspace/Models/Environment.swift
+++ b/Interspace/Models/Environment.swift
@@ -14,9 +14,9 @@ enum AppEnvironment: String, CaseIterable {
                 return url
             }
             // Fallback for development
-            return "https://staging-api.interspace.fi/api"
+            return "https://staging-api.interspace.fi/api/v2"
         case .staging:
-            return "https://staging-api.interspace.fi/api"
+            return "https://staging-api.interspace.fi/api/v2"
         case .production:
             return "https://staging-api.interspace.fi/api/v2"
         }


### PR DESCRIPTION
## Summary
- Update development and staging API URLs to use v2 endpoints
- Ensure consistency across all environments

## Changes
- Development API URL: Now points to v2 endpoint
- Staging API URL: Now points to v2 endpoint
- Production already using v2

## Test plan
- [ ] Build and run in development mode
- [ ] Verify API calls work correctly with v2 endpoints
- [ ] Test in staging environment

🤖 Generated with [Claude Code](https://claude.ai/code)