### PR TITLE
fix: Remove development team from project configuration

### DIFF
--- a/Interspace.xcodeproj/project.pbxproj
+++ b/Interspace.xcodeproj/project.pbxproj
@@ -2134,7 +2134,6 @@
 				LastUpgradeCheck = 1130;
 				TargetAttributes = {
 					13B07F861A680F5B00A75B9A = {
-						DevelopmentTeam = 579ZB4FX6N;
 						LastSwiftMigration = 1250;
 					};
 				};

--- a/Interspace.xcodeproj/xcuserdata/ardaerturk.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Interspace.xcodeproj/xcuserdata/ardaerturk.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -17,7 +17,7 @@
 		<key>InterspaceUITests.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>21</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>


### PR DESCRIPTION
## Summary
- Remove hardcoded development team ID from project settings
- Enable automatic code signing management by Xcode Cloud

## Why this change?
Having a hardcoded development team ID in the project file can cause issues when:
- Different developers work on the project
- Using Xcode Cloud for CI/CD
- Building in different environments

Removing it allows Xcode and Xcode Cloud to manage code signing automatically based on the current environment.

## Test plan
- [ ] Build project locally to verify code signing works
- [ ] Verify Xcode Cloud can build without team conflicts
- [ ] Ensure TestFlight deployments work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)