### PR TITLE
Fix navigation titles display across all tabs

### DIFF
--- a/Interspace/Views/AppsView.swift
+++ b/Interspace/Views/AppsView.swift
@@ -14,27 +14,42 @@ struct AppsView: View {
     @State private var showNotifications = false
     
     var body: some View {
-        NavigationStack {
-            ZStack {
+        ZStack {
             // Native iPhone-style background
             Color.black
                 .ignoresSafeArea(.all)
             
-            if viewModel.apps.isEmpty && viewModel.folders.isEmpty && !viewModel.isLoading {
-                emptyStateView
-            } else {
-                // Main springboard grid
-                SpringboardGrid(
-                    apps: $viewModel.apps,
-                    folders: $viewModel.folders,
-                    isEditMode: $isEditMode,
-                    onAppTap: handleAppTap,
-                    onFolderTap: handleFolderTap,
-                    onAddApp: {
-                        showAddApp = true
-                    },
-                    viewModel: viewModel
-                )
+            VStack(spacing: 0) {
+                // Custom large title header that mimics native iOS style
+                HStack(alignment: .bottom) {
+                    Text("Apps")
+                        .font(.system(size: 34, weight: .bold))
+                        .foregroundColor(.white)
+                    
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+                .padding(.bottom, 8)
+                
+                if viewModel.apps.isEmpty && viewModel.folders.isEmpty && !viewModel.isLoading {
+                    emptyStateView
+                } else {
+                    // Main springboard grid
+                    SpringboardGrid(
+                        apps: $viewModel.apps,
+                        folders: $viewModel.folders,
+                        isEditMode: $isEditMode,
+                        onAppTap: handleAppTap,
+                        onFolderTap: handleFolderTap,
+                        onAddApp: {
+                            showAddApp = true
+                        },
+                        viewModel: viewModel
+                    )
+                }
+                
+                Spacer()
             }
             
             // Loading overlay
@@ -48,18 +63,18 @@ struct AppsView: View {
                         .scaleEffect(1.5)
                 }
             }
-            }
-            .navigationBarTitle("Apps")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    StandardToolbarButtons(
-                        showUniversalAddTray: $showUniversalAddTray,
-                        showAbout: $showAbout,
-                        showSecurity: $showSecurity,
-                        showNotifications: $showNotifications,
-                        initialSection: .app
-                    )
-                }
+        }
+        .navigationTitle("")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                StandardToolbarButtons(
+                    showUniversalAddTray: $showUniversalAddTray,
+                    showAbout: $showAbout,
+                    showSecurity: $showSecurity,
+                    showNotifications: $showNotifications,
+                    initialSection: .app
+                )
             }
         }
         .sheet(isPresented: $showUniversalAddTray) {

--- a/Interspace/Views/Components/StandardToolbarButtons.swift
+++ b/Interspace/Views/Components/StandardToolbarButtons.swift
@@ -100,26 +100,3 @@ struct StandardToolbarButtons: View {
     }
 }
 
-// MARK: - Navigation Bar Title Modifier
-struct NavigationBarTitleModifier: ViewModifier {
-    let title: String
-    
-    func body(content: Content) -> some View {
-        content
-            .navigationTitle(title)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .principal) {
-                    Text(title)
-                        .font(.system(size: 17, weight: .semibold))
-                        .foregroundColor(.white)
-                }
-            }
-    }
-}
-
-extension View {
-    func navigationBarTitle(_ title: String) -> some View {
-        self.modifier(NavigationBarTitleModifier(title: title))
-    }
-}

--- a/Interspace/Views/ContentView.swift
+++ b/Interspace/Views/ContentView.swift
@@ -395,7 +395,6 @@ struct MainTabView: View {
             .tag(Tab.wallet)
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity) // Force TabView to fill
-        .edgesIgnoringSafeArea(.all) // Ignore safe areas
         .accentColor(DesignTokens.Colors.primary)
         .animation(.interactiveSpring(response: 0.5, dampingFraction: 0.8), value: selectedTab)
         .preferredColorScheme(.dark) // Consistent dark mode
@@ -420,10 +419,10 @@ struct MainTabView: View {
             UITabBar.appearance().standardAppearance = tabAppearance
             UITabBar.appearance().scrollEdgeAppearance = tabAppearance
             
-            // Configure navigation bar for proper full-screen layout
+            // Configure navigation bar for native Apple dark mode look
             let navAppearance = UINavigationBarAppearance()
-            navAppearance.configureWithOpaqueBackground()
-            navAppearance.backgroundColor = UIColor.black.withAlphaComponent(0.9)
+            navAppearance.configureWithDefaultBackground()
+            navAppearance.backgroundColor = UIColor.black
             navAppearance.titleTextAttributes = [
                 .foregroundColor: UIColor.white,
                 .font: UIFont.systemFont(ofSize: 17, weight: .semibold)
@@ -432,12 +431,12 @@ struct MainTabView: View {
                 .foregroundColor: UIColor.white,
                 .font: UIFont.systemFont(ofSize: 34, weight: .bold)
             ]
-            navAppearance.shadowColor = .clear
             
             UINavigationBar.appearance().standardAppearance = navAppearance
             UINavigationBar.appearance().scrollEdgeAppearance = navAppearance
             UINavigationBar.appearance().compactAppearance = navAppearance
             UINavigationBar.appearance().tintColor = UIColor.white
+            UINavigationBar.appearance().prefersLargeTitles = true
         }
     }
 }

--- a/Interspace/Views/ProfileView.swift
+++ b/Interspace/Views/ProfileView.swift
@@ -23,55 +23,50 @@ struct ProfileView: View {
     @Environment(\.colorScheme) var colorScheme
     
     var body: some View {
-        NavigationStack {
-            ZStack {
-                Color.black
-                    .ignoresSafeArea()
-                
-                List {
-                    // Profile Header Section
-                    profileHeaderSection
-                    
-                    // Empty state or account sections
-                    if viewModel.linkedAccounts.isEmpty && viewModel.socialAccounts.isEmpty && viewModel.emailAccounts.isEmpty {
-                        emptyStateView
-                    } else {
-                        // Linked Wallets Section
-                        if !viewModel.linkedAccounts.isEmpty {
-                            linkedWalletsSection
-                        }
-                        
-                        // Email Accounts Section
-                        if !viewModel.emailAccounts.isEmpty {
-                            emailAccountsSection
-                        }
-                        
-                        // Social Accounts Section
-                        if !viewModel.socialAccounts.isEmpty {
-                            socialAccountsSection
-                        }
-                    }
-                    
-                    // Bottom Actions
-                    bottomActionsSection
+        List {
+            // Profile Header Section
+            profileHeaderSection
+            
+            // Empty state or account sections
+            if viewModel.linkedAccounts.isEmpty && viewModel.socialAccounts.isEmpty && viewModel.emailAccounts.isEmpty {
+                emptyStateView
+            } else {
+                // Linked Wallets Section
+                if !viewModel.linkedAccounts.isEmpty {
+                    linkedWalletsSection
                 }
-                .listStyle(.insetGrouped)
-                .scrollContentBackground(.hidden)
-                .refreshable {
-                    await viewModel.refreshProfile()
+                
+                // Email Accounts Section
+                if !viewModel.emailAccounts.isEmpty {
+                    emailAccountsSection
+                }
+                
+                // Social Accounts Section
+                if !viewModel.socialAccounts.isEmpty {
+                    socialAccountsSection
                 }
             }
-            .navigationBarTitle("Profile")
-            .toolbar {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    StandardToolbarButtons(
-                        showUniversalAddTray: $showUniversalAddTray,
-                        showAbout: $showAbout,
-                        showSecurity: $showSecurity,
-                        showNotifications: $showNotifications,
-                        initialSection: .none
-                    )
-                }
+            
+            // Bottom Actions
+            bottomActionsSection
+        }
+        .listStyle(.insetGrouped)
+        .scrollContentBackground(.hidden)
+        .background(Color.black)
+        .refreshable {
+            await viewModel.refreshProfile()
+        }
+        .navigationTitle("Profile")
+        .navigationBarTitleDisplayMode(.large)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                StandardToolbarButtons(
+                    showUniversalAddTray: $showUniversalAddTray,
+                    showAbout: $showAbout,
+                    showSecurity: $showSecurity,
+                    showNotifications: $showNotifications,
+                    initialSection: .none
+                )
             }
         }
         .preferredColorScheme(.dark) // iOS 26 Liquid Glass is optimized for dark mode


### PR DESCRIPTION
## Summary
- Fixed navigation titles not appearing on Profile and Wallet tabs
- Implemented custom large title for Apps tab (non-scrollable)
- Resolved double NavigationStack nesting issues

## Problem
Navigation titles were not visible on Profile and Wallet tabs. The Apps tab needed a custom always-visible title since it's non-scrollable, while Profile and Wallet tabs needed standard SwiftUI large titles that collapse on scroll.

## Solution
1. **Removed nested NavigationStack** from individual views to fix double nesting
2. **Created custom large title header** for Apps tab that mimics Apple's native style
3. **Fixed Profile and Wallet tabs** to use standard SwiftUI navigation with proper large titles
4. **Removed `.edgesIgnoringSafeArea(.all)`** from TabView which was interfering with navigation bars
5. **Cleaned up navigation bar appearance** configuration for consistent dark mode experience

## Testing
- [x] Apps tab displays custom large title that's always visible
- [x] Profile tab shows large "Profile" title that collapses on scroll
- [x] Wallet tab shows large "Wallet" title that collapses on scroll
- [x] Navigation hierarchy works correctly without double nesting
- [x] Dark mode appearance is consistent across all tabs

## Screenshots
The navigation now provides a native iOS experience similar to Apple's Settings, Health, and other system apps.

🤖 Generated with [Claude Code](https://claude.ai/code)